### PR TITLE
Updates to `get_packages()` function

### DIFF
--- a/R/package_get.R
+++ b/R/package_get.R
@@ -116,10 +116,10 @@ get_packages <- function(pkg) {
       repo$latest <- get_latest_release(repo$full_name)
       repo$updated <- lubridate::as_date(get_latest_date(repo$full_name))
       # repo$contributors <- get_contributors(repo$full_name)
-      repo <- tibble::as_tibble(repo)
+      repo <- as.data.frame(repo)
     })
     
-    repos <- dplyr::bind_rows(repos)
+    repos <- tibble::as_tibble(dplyr::bind_rows(repos))
     print(repos, width = Inf, pillar.min_chars = Inf)
   }
   

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ used to discover which packages are currently available.
 
 ``` r
 library(qData)
+```
+
+    ## Warning: package 'tibble' was built under R version 4.0.4
+
+``` r
 get_packages()
 ```
 
@@ -77,12 +82,12 @@ get_packages()
     ## 3 qStates  globalgov/qStates 
     ##   description                                             installed latest
     ##   <chr>                                                   <chr>     <chr> 
-    ## 1 An R portal for ensembled global governance data        0.3.5     0.3.4 
+    ## 1 An R portal for ensembled global governance data        0.3.5     0.3.5 
     ## 2 qPackage for ensembled data on environmental agreements 0.0.2     0.0.2 
     ## 3 qPackage for ensembled data on sovereign states         0.0.3     0.0.3 
     ##   updated   
     ##   <date>    
-    ## 1 2021-03-23
+    ## 1 2021-03-24
     ## 2 2021-02-22
     ## 3 2021-02-22
 


### PR DESCRIPTION
These changes updates the `get_packages()` function to address issues related to workflow checks for merging develop and main branches. Please refer to the PR below for a more detailed account of the changes in this version of qData.   
