### PR TITLE
Fixed #144 by substituting NA where qPackage is not installed locally

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Updated `get_packages()` function
   * Fixed bug with dates in `get_packages()` by changing dependencies to `{lubridate}`
   * Updated formatting of the returned tibble to display more clearly the information on qPackages
+  * Fixed #144 by substituting NA where a listed qPackage is not installed locally
 
 # qData 0.3.4
 

--- a/R/package_get.R
+++ b/R/package_get.R
@@ -84,7 +84,13 @@ get_packages <- function(pkg) {
     }
     
     get_installed_release <- function(name){
-      installed <- sapply(name, function(x) as.character(utils::packageVersion(x)))
+      installed <- utils::installed.packages()
+      installed_v <- sapply(name, function(x){
+        ifelse(x %in% installed, 
+               as.character(utils::packageVersion(x)),
+               NA_character_)
+      })
+      installed_v
     }
     
     # get_contributors <- function(full_name){


### PR DESCRIPTION
# Checklist:

- [ ] PR form
  - [x] I have given this pull request an informative title
  - [ ] Description above itemizes changes under subtitles, e.g. "## Collection""
  - [ ] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [x] Package builds on my OS without issues
- [ ] PR checks all pass for latest commit
  - [ ] Package builds on Mac
  - [ ] Package builds on Windows
  - [ ] Package builds on Linux
  - [ ] CodeCov check: Package improves or maintains good test coverage
  - [x] CodeFactor check: Package improves or maintains good style
- [x] Documentation
  - [x] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [x] Any longer functions are commented inline so that it is easier to debug in the future
  - [x] PR description above and the NEWS.md file are aligned
  - [x] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
